### PR TITLE
Fix to require Nokogiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork to fix a bug
+
+The bug was an exception due to a missing require statement.  This fork adds the missing require statement and also adds the Gem dependency for nokogiri.
+
 # Forem + Redcarpet = :heart:
 
 Simply specify this gem as a dependency of your application that also contains Forem:

--- a/forem-redcarpet.gemspec
+++ b/forem-redcarpet.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email       = ["radarlistener@gmail.com"]
   s.homepage    = ""
   s.summary     = %q{Provides Redcarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
-  s.description = %q{Provides Recarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
+  s.description = %q{This is a fork of the original code to provide a fix for an exception due to a missing require statement.  Provides Recarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]

--- a/forem-redcarpet.gemspec
+++ b/forem-redcarpet.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 
+  s.add_dependency 'nokogiri'
   s.add_dependency 'redcarpet', '2.0.1'
   s.add_dependency 'pygments.rb', '0.2.4'
 end

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -1,5 +1,6 @@
 require 'redcarpet'
 require 'pygments'
+require 'nokogiri'
 
 module Forem
   module Formatters

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -1,5 +1,6 @@
 require 'redcarpet'
 require 'pygments'
+# AJF: The following line is new in this fork to fix an exception from line on line 22 of this file
 require 'nokogiri'
 
 module Forem


### PR DESCRIPTION
We were getting an exception when using forem which was caused by the following line of code:

lib/forem/formatters/redcarpet.rb, line 20:
        doc = Nokogiri::HTML::DocumentFragment.parse(html.to_s)

Nokogiri could not be resolved without the include.  Also, Nokogiri is required by the gem, so it should be added to the dependency list.
