### PR TITLE
A little modernization

### DIFF
--- a/forem-redcarpet.gemspec
+++ b/forem-redcarpet.gemspec
@@ -3,17 +3,17 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "forem-redcarpet"
-  s.version     = "1.0.2"
+  s.version     = "1.0.3"
   s.authors     = ["Ryan Bigg"]
   s.email       = ["radarlistener@gmail.com"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/radar/forem-redcarpet"
   s.summary     = %q{Provides Redcarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
-  s.description = %q{Provides Recarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
+  s.description = %q{Provides Redcarpet markup (with syntax highlighting by pygments.rb) for Forem posts}
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'nokogiri'
-  s.add_dependency 'redcarpet', '3.0.0'
-  s.add_dependency 'pygments.rb', '0.5.4'
+  s.add_runtime_dependency 'nokogiri', '~>1.6'
+  s.add_runtime_dependency 'redcarpet', '~>3.3'
+  s.add_runtime_dependency 'pygments.rb', '~>0.6'
 end

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -24,7 +24,9 @@ module Forem
       def self.syntax_highlight(html)
         doc = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
         doc.css("pre code[@class]").each do |code|
-          code.replace Pygments.highlight(code.text.rstrip, :lexer => code[:class], :class => "forem_highlight")
+          if Pygments::Lexer.find(code[:class])
+            code.replace Pygments.highlight(code.text.rstrip, :lexer => code[:class], :class => "forem_highlight")
+          end
         end
         doc.to_s
       end

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -25,7 +25,7 @@ module Forem
         doc = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
         doc.css("pre code[@class]").each do |code|
           if Pygments::Lexer.find(code[:class])
-            code.replace Pygments.highlight(code.text.rstrip, :lexer => code[:class], :class => "forem_highlight")
+            code.parent.replace Pygments.highlight(code.text.rstrip, :lexer => code[:class], :class => "forem_highlight")
           end
         end
         doc.to_s

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -13,7 +13,11 @@ module Forem
 
       def self.blockquote(text)
         text.split("\n").map do |line|
-          "> " + line
+          if line[0] == ">"
+            ">" + line
+          else
+            "> " + line
+          end
         end.join("\n")
       end
 

--- a/lib/forem/formatters/redcarpet.rb
+++ b/lib/forem/formatters/redcarpet.rb
@@ -7,7 +7,9 @@ module Forem
     class Redcarpet
       def self.format(text)
         options = [:hard_wrap, :filter_html, :autolink, :no_intraemphasis, :fenced_code, :gh_blockcode]
-        renderer = ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML, :fenced_code_blocks => true)
+        renderer = ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML,
+                                             :strikethrough=> true,
+                                             :fenced_code_blocks => true)
         syntax_highlight(Forem.formatter.sanitize(renderer.render(text))).html_safe
       end
 


### PR DESCRIPTION
Two small patches:
1. I made the dependencies less strict, which allows redcarpet `~>3.3`
2. Nested quotes, previously like this:

``` markdown
> > foobar
```

became

``` markdown
>> foobar
```

Notice `>>` vs `> >`.
